### PR TITLE
If a file extension is specified in a require it is kept. Closes #1

### DIFF
--- a/examples/stark/sansa.coffee
+++ b/examples/stark/sansa.coffee
@@ -1,0 +1,4 @@
+father = require './eddard'
+brother = require './robb.coffee'
+
+module.exports = {}

--- a/lib/findChangedRequires/changedRequiresForSingleFile.js
+++ b/lib/findChangedRequires/changedRequiresForSingleFile.js
@@ -8,7 +8,7 @@ module.exports = function(f, getNewLocation) {
     var newRequireLocation = getNewLocation(r.filePath);
 
     if (newFileLocation.isMoved || newRequireLocation.isMoved) {
-      var newPath = path.relative(path.dirname(newFileLocation.fullPath), newRequireLocation.requirePath);
+      var newPath = path.relative(path.dirname(newFileLocation.fullPath), newRequireLocation.requirePath + path.extname(r.fullPath));
       if (newPath[0] != '.') newPath = './' + newPath;
 
       if (newPath !== r.path) {

--- a/test/changedRequiresByFile_spec.coffee
+++ b/test/changedRequiresByFile_spec.coffee
@@ -14,7 +14,7 @@ describe 'changedRequiresByFile', ->
       files = files.sort (a,b) -> a.from > b.from
 
     it 'has the correct fixes', ->
-      expect(files.length).to.equal 2
+      expect(files.length).to.equal 3
 
     it 'fixes the outbound require in the file', ->
       expect(files[1].requires.length).to.equal 1
@@ -27,6 +27,12 @@ describe 'changedRequiresByFile', ->
       inbound = files[0].requires[0]
       expect(inbound.path).to.equal './robb'
       expect(inbound.newPath).to.equal '../deceased/robb'
+
+    it 'keeps the extension in a referencing file', ->
+      expect(files[2].requires.length).to.equal 1
+      inbound = files[2].requires[0]
+      expect(inbound.path).to.equal './robb.coffee'
+      expect(inbound.newPath).to.equal '../deceased/robb.coffee'
 
   describe 'moving a directory', ->
     before ->

--- a/test/fileFinder_spec.coffee
+++ b/test/fileFinder_spec.coffee
@@ -34,8 +34,14 @@ describe 'fileFinder', ->
       expect(eddard.filetype).to.equal('js')
       expect(eddard.relativePath).to.equal('stark/eddard.js')
 
+    it 'can find sansa',  ->
+      sansa = result[2]
+      expect(sansa.fullPath).to.equal(path.normalize(starkPath + '/sansa.coffee'))
+      expect(sansa.filetype).to.equal('coffee')
+      expect(sansa.relativePath).to.equal('stark/sansa.coffee')
+
     it 'can find catelyn',  ->
-      catelyn = result[2]
+      catelyn = result[3]
       expect(catelyn.fullPath).to.equal(path.normalize(tullyPath + '/catelyn.js'))
       expect(catelyn.filetype).to.equal('js')
       expect(catelyn.relativePath).to.equal('tully/catelyn.js')


### PR DESCRIPTION
I basically just ensured that if an extension is specified for the `fullPath` of a require, it will use that in the new one. This prevents breakages in certain situations such as with a `hbs` or `json` file.

Sorry about the commit message not making much sense, I put the word "require" in code quotes and it  stripped out the whole word.
