### PR TITLE
Scope path resolution does not works with path relative to current working directory

### DIFF
--- a/lib/buildJob.js
+++ b/lib/buildJob.js
@@ -9,7 +9,7 @@ module.exports = function(options) {
   var files = _.map(blowOutPath);
   var from = files.slice(0, files.length -1);
   var to = files.length && files[files.length - 1];
-  var base = scopePresent ? path.normalize(options.scope) : process.cwd();
+  var base = scopePresent ? path.resolve(options.scope) : process.cwd();
   var ignore = readIgnores(base);
 
   return {


### PR DESCRIPTION
Using the command line, passing a `--scope` with a relative path does not
works has expected (the scope argument is not resolved):

This works as expected:
```
trucker --scope $(pwd)/src -i ./src/app/index.js
```

This should works as above:
```
trucker --scope ./src -i ./src/app/index.js
```