### PR TITLE
Pseudo-absolute pattern in .gitignore are ignored

### DIFF
--- a/lib/ignoreFilter.js
+++ b/lib/ignoreFilter.js
@@ -1,33 +1,18 @@
 var Minimatch = require('minimatch').Minimatch;
 var path = require('path');
+var ignore = require('ignore');
 
 module.exports = function ignoreFilter(ignoreBase, ignorePatterns, files) {
-  var matchers = getMatchers(ignorePatterns || []);
-  var nameFilter = shouldInclude.bind(null, ignoreBase, matchers);
-  return files.filter(nameFilter);
+  var filter = ignore({ twoGlobstars: true })
+    .addPattern(ignorePatterns)
+    .createFilter();
+
+  return files.filter(function (file) {
+    var relativeToBase = path.relative(ignoreBase, file.fullPath);
+
+    // don't exclude files above ignore file
+    if (relativeToBase.indexOf('..') === 0) return true;
+
+    return filter(relativeToBase)
+  })
 };
-
-function getMatchers(patterns) {
-  var matchers = [];
-  patterns.forEach(function(pattern) {
-    matchers.push(createMatcher(pattern));
-    matchers.push(createMatcher(pattern + '/**'));
-  });
-  return matchers;
-}
-
-function createMatcher(pattern) {
-  return new Minimatch(pattern, {matchBase: true});
-}
-
-function shouldInclude(base, matchers, file) {
-  var relativeToBase = path.relative(base, file.fullPath);
-
-  // don't exclude files above ignore file
-  if (relativeToBase.indexOf('..') === 0) return true;
-
-  for (var i = 0; i < matchers.length; i++) {
-    if (matchers[i].match(relativeToBase)) return false;
-  }
-  return true;
-}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "babel-core": "^5.8.23",
     "coffee-script": "1.6.0",
+    "ignore": "^2.2.19",
     "minimatch": "^3.0.0",
     "mkdirp": "~0.3",
     "optimist": "~0.6.0",


### PR DESCRIPTION
.gitignore patterns may contain pseudo-absolute path
such as `/doc` to match pattern relative to repository
root. Hence, `/doc` should match (and ignore) `doc/index.js` but not `src/doc/index.js`

Currently a `/doc` pattern won't exclude the `doc` at the root of the git repository. And removing the `/` in the pattern would be to greedy by excluding any doc folder, anywhere in the repository.

By using the dedicated [ignore](https://github.com/kaelzhang/node-ignore) tools, the ignore filters should behave as expected.