### PR TITLE
feat: Add an --exclude options to extend the .gitignore patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ in the examples directory (provided), you can try the following (add ```-n``` fo
 
 ```-q, --quiet``` suppress output
 
+```-e, --exclude``` Add file glob pattern to ignore to those found in the `.gitignore` file. Repeat this options to add many patterns.
+
 # Supported file types
 
 Trucker supports javascript and coffeescript source files. It can handle projects that have both of these file types intermixed.
@@ -99,6 +101,8 @@ Trucker supports javascript and coffeescript source files. It can handle project
 # Ignored files
 
 Trucker ignores files using the first .gitignore it finds, starting from the base directory (usually cwd), and ascending to the root.
+
+See too the `--exclude` option above.
 
 # Limitations
 
@@ -115,4 +119,3 @@ Trucker doesn't recognize this, for example:
 var x = '../foo/bar';
 var y = require(x);
 ```
-

--- a/cli
+++ b/cli
@@ -24,13 +24,20 @@ var options = optimist
   .describe('s', 'Set top "scope" directory for scanning for dependencies (default: pwd)')
   .string('q')
   .alias('q', 'quiet')
-  .describe('q', 'Suppress output');
+  .describe('q', 'Suppress output')
+  .string('e')
+  .alias('e', 'exclude')
+  .describe('e', 'Add file glob pattern to exclude (repeatable)');
 
 var argv = options.argv,
   fileCount = argv._length,
   requiredFileCount = argv.i ? 1 : 2;
 
 if (! (argv.h || argv.i || argv.m || argv.n || argv.u)) {
+}
+
+if (argv.exclude && (typeof argv.exclude === 'string')) {
+  argv.e = argv.exclude = [argv.exclude]
 }
 
 if (argv.h || fileCount < requiredFileCount) {

--- a/lib/buildJob.js
+++ b/lib/buildJob.js
@@ -12,6 +12,10 @@ module.exports = function(options) {
   var base = scopePresent ? path.resolve(options.scope) : process.cwd();
   var ignore = readIgnores(base);
 
+  if (options.exclude) {
+    ignore.patterns = ignore.patterns.concat(options.exclude)
+  }
+
   return {
     base: base,
     ignore: ignore,


### PR DESCRIPTION
This PR is a feature suggestion and may require a refactoring before a merge.

This address the following situations:
- A project with huge files un-relevant for trucker but we still need to commit (a project with a commited dist, or legacy vendors bundle)
- A project with some relevant files excluded by a .gitignore: this option allow the use of a negation in the pattern to prevent ignoring those files ( --exclude "!do-not-ignore-me.js" )
