### PR TITLE
Demonstrate bug in regex findRequires

### DIFF
--- a/test/findRequires_spec.js
+++ b/test/findRequires_spec.js
@@ -69,22 +69,26 @@ export const fetchLookup = query =>
 
     it('handles import in a file that babylon can\'t fully parse',  () =>  {
       const code = `import * as x from './y';
+import z from './z';
 let foo;
 foo = foo || () => {}; //babylon can't handle this for some reason
       `;
       const requires = findRequires('js', code);
-      expect(requires.length).to.eql(1);
+      expect(requires.length).to.eql(2);
       expect(requires[0].path).to.equal('./y');
+      expect(requires[1].path).to.equal('./z');
     });
 
     it('handles require in a file that babylon can\'t fully parse',  () =>  {
       const code = `const x = require('./y');
+const z = require('./z');
 let foo;
 foo = foo || () => {}; //babylon can't handle this for some reason
       `;
       const requires = findRequires('js', code);
-      expect(requires.length).to.eql(1);
+      expect(requires.length).to.eql(2);
       expect(requires[0].path).to.equal('./y');
+      expect(requires[1].path).to.equal('./z');
     });
 
 


### PR DESCRIPTION
DO NOT MERGE THIS
This is simply a demonstration of a bug I noticed in the regexFinder.

In cases that I've tested, when `javascriptRequireFinder` falls back to use the `regexFinder`, it strangely loses every other require.  The tests included here fail as the result will only include one of the two expected requires.  If the source code has 3 requires, the result would only include the first and third.